### PR TITLE
Implemented tile width + height

### DIFF
--- a/src/ldtk/Layer_Tiles.hx
+++ b/src/ldtk/Layer_Tiles.hx
@@ -86,6 +86,8 @@ class Layer_Tiles extends ldtk.Layer {
 						s.flipX = tile.flipBits & 1 != 0;
 						s.flipY = tile.flipBits & 2 != 0;
 						s.frame = tileset.getFrame(tile.tileId);
+						s.width = cWid;
+						s.height = cHei;
 						target.add(s);
 					}
 


### PR DESCRIPTION
Makes it possible for `FlxG.collide();` to work for easy collision checks with map's group

Sample:

```haxe
package;

import flixel.FlxG;
import flixel.FlxSprite;
import flixel.FlxState;
import flixel.group.FlxSpriteGroup;

class Sample extends FlxState {
	public var player:FlxSprite;

	var collider:FlxSpriteGroup;
	var background:FlxSpriteGroup;

	override public function create() {
		super.create();

		var project = new LdtkProject();

		// Create a FlxGroup for all level layers
		collider = new FlxSpriteGroup();

		background = new FlxSpriteGroup();
		add(background);

		// Iterate all world levels
		for (level in project.levels) {
			// Place it using level world coordinates (in pixels)
			collider.setPosition(level.worldX, level.worldY);
			background.setPosition(level.worldX, level.worldY);

			createEntities(level.l_Entities);

			// Attach level background image, if any
			if (level.hasBgImage())
				background.add(level.getBgSprite());

			// Render layer "Background"
			level.l_Background.render(background);

			// Render layer "Collisions"
			level.l_Collisions.render(collider);
		}

		// Makes sure every object in the collider's group can't be moved by FlxG.collide();
		for (tile in collider) {
			tile.immovable = true;
		}
		add(collider);
	}

	function createEntities(entityLayer:LdtkProject.Layer_Entities) {
		var x = entityLayer.all_Player[0].pixelX;
		var y = entityLayer.all_Player[0].pixelY;

		player = new FlxSprite(x, y);
		player.makeGraphic(16, 16);
		add(player);
	}

	override public function update(elapsed:Float) {
		super.update(elapsed);

		FlxG.collide(collider, player);
	}
}
```