### PR TITLE
add dependency, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ Samples are built to **WebGL** (Javascript) and **Hashlink** targets, but you ca
 
 ### Requirements
 
-You need a standard **Haxe** install, and both *heaps* and *deepnightLibs* libraries installed:
+You need a standard **Haxe** install, and the following libraries installed: *heaps* (from source), *deepnightLibs* (from source), *hlsdl*:
 
 ```
 haxelib git heaps https://github.com/HeapsIO/heaps.git
 
 haxelib git deepnightLibs https://github.com/deepnight/deepnightLibs.git
+
+haxelib install hlsdl
 ```
 
 ### Building samples

--- a/haxelib.json
+++ b/haxelib.json
@@ -8,5 +8,7 @@
   "classPath": "src/",
   "releasenote": "API updated for 0.9.3",
   "contributors": ["sbenard"],
-  "dependencies": {}
+  "dependencies": {
+    "deepnightLibs": "1.0.59"
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds the deepnightLibs dependency to the `haxelib.json` file, which should resolve #11 and #12 

In the process of making this PR, I ran into an error where I needed to install `hlsdl`, so I added that to the README. 
```
➜  samples git:(master) ✗ haxe buildAll.hxml 
Error: Error: Cannot process [hlsdl]: Library hlsdl is not installed : run 'haxelib install hlsdl'
```

I can change that part in the README, or take it out of this PR, if that shouldn't be included in here. 

## Testing

Ran the JS tests, and it returned with a success message
```
➜  ldtk-haxe-api git:(master) ✗ haxe tests/js.hxml 

Success.
```

## Caveats

I've never done Haxe development of any kind, so I have no idea if this is good or right :man_shrugging: 