### PR TITLE
set FlxSprite width and height to grid cell size

### DIFF
--- a/src/ldtk/Layer_Tiles.hx
+++ b/src/ldtk/Layer_Tiles.hx
@@ -88,8 +88,8 @@ class Layer_Tiles extends ldtk.Layer {
 						s.flipX = tile.flipBits & 1 != 0;
 						s.flipY = tile.flipBits & 2 != 0;
 						s.frame = untypedTileset.getFrame(tile.tileId);
-						s.width = cWid;
-						s.height = cHei;
+						s.width = gridSize;
+						s.height = gridSize;
 						target.add(s);
 					}
 


### PR DESCRIPTION
When using the flixel render for LDtk layer I found that the collision boxes were incorrectly sized.

Looking at the code it is using the level width and level height to set the FlxSprite width and height.

This fix updates the render logic to use gridSize instead which is the size of the cell on a layer tile rather than the number of cells the level is wide or high.