### PR TITLE
Add newly missing parameter to Version.lower call

### DIFF
--- a/src/ldtk/macro/TypeBuilder.hx
+++ b/src/ldtk/macro/TypeBuilder.hx
@@ -130,7 +130,7 @@ class TypeBuilder {
 				error("Failed to parse project JSON");
 			}
 
-		if( dn.Version.lower(json.jsonVersion, MIN_JSON_VERSION) )
+		if( dn.Version.lower(json.jsonVersion, MIN_JSON_VERSION, true) )
 			error('JSON version: "${json.jsonVersion}", required at least: "$MIN_JSON_VERSION"');
 	}
 


### PR DESCRIPTION
deepnightLibs 1.0.68 breaks builds using the latest version of ldtk-haxe-api because of the interface change