### PR TITLE
Make Tileset.hx take into account spacing and padding for calculating Atlas coordinates

### DIFF
--- a/src/ldtk/Tileset.hx
+++ b/src/ldtk/Tileset.hx
@@ -29,7 +29,7 @@ class Tileset {
 	/** Spacing between each tile in pixels */
 	public var spacing: Int;
 
-	var cWid(get,never) : Int; inline function get_cWid() return Math.ceil(pxWid/tileGridSize);
+	var cWid(get,never) : Int; inline function get_cWid() return Math.ceil(pxWid-padding*2)/(tileGridSize + spacing));
 
 	/** Untyped Enum based tags (stored as String). The "typed" getter method is created in macro. **/
 	var untypedTags : Map< String, Map<Int,Int> >;
@@ -67,14 +67,14 @@ class Tileset {
 		Get X pixel coordinate (in atlas image) from a specified tile ID
 	**/
 	public inline function getAtlasX(tileId:Int) {
-		return ( tileId - Std.int( tileId / cWid ) * cWid ) * tileGridSize;
+		return ( tileId - Std.int( tileId / cWid ) * cWid ) * (tileGridSize + spacing) + padding;
 	}
 
 	/**
 		Get Y pixel coordinate (in atlas image) from a specified tile ID
 	**/
 	public inline function getAtlasY(tileId:Int) {
-		return Std.int( tileId / cWid ) * tileGridSize;
+		return Std.int( tileId / cWid ) * (tileGridSize + spacing) + padding;
 	}
 
 

--- a/src/ldtk/Tileset.hx
+++ b/src/ldtk/Tileset.hx
@@ -29,7 +29,7 @@ class Tileset {
 	/** Spacing between each tile in pixels */
 	public var spacing: Int;
 
-	var cWid(get,never) : Int; inline function get_cWid() return Math.ceil(pxWid-padding*2)/(tileGridSize + spacing));
+	var cWid(get,never) : Int; inline function get_cWid() return Math.ceil((pxWid-padding*2)/(tileGridSize + spacing));
 
 	/** Untyped Enum based tags (stored as String). The "typed" getter method is created in macro. **/
 	var untypedTags : Map< String, Map<Int,Int> >;


### PR DESCRIPTION
ldtk-haxe-api layer render methods don't work as intended if the tileset has spacing or padding. 

Tileset.hx was making X,Y atlas calculations without taking into account spacing or padding.

Haven't added tests yet (will try to do that this week), any tips on adding tests would be helpful.