### PR TITLE
add spacing support to Tileset

### DIFF
--- a/src/ldtk/Tileset.hx
+++ b/src/ldtk/Tileset.hx
@@ -29,7 +29,8 @@ class Tileset {
 	/** Spacing between each tile in pixels */
 	public var spacing: Int;
 
-	var cWid(get,never) : Int; inline function get_cWid() return Math.ceil(pxWid/tileGridSize);
+	var cWid(get,never) : Int; inline function get_cWid() return
+        Math.ceil(pxWid/(tileGridSize + spacing));
 
 	/** Untyped Enum based tags (stored as String). The "typed" getter method is created in macro. **/
 	var untypedTags : Map< String, Map<Int,Int> >;
@@ -67,14 +68,15 @@ class Tileset {
 		Get X pixel coordinate (in atlas image) from a specified tile ID
 	**/
 	public inline function getAtlasX(tileId:Int) {
-		return ( tileId - Std.int( tileId / cWid ) * cWid ) * tileGridSize;
+        return ( tileId - Std.int( tileId / cWid ) * cWid ) * (tileGridSize +
+                spacing);
 	}
 
 	/**
 		Get Y pixel coordinate (in atlas image) from a specified tile ID
 	**/
 	public inline function getAtlasY(tileId:Int) {
-		return Std.int( tileId / cWid ) * tileGridSize;
+		return Std.int( tileId / cWid ) * (tileGridSize + spacing);
 	}
 
 	/**
@@ -82,7 +84,8 @@ class Tileset {
 		WARNING: tile spacing is not supported yet!
 	**/
 	public inline function getTileIdFromCoords(pixelX:Int, pixelY:Int) {
-		return Std.int( (pixelX-padding) / tileGridSize )  +  cWid * Std.int( pixelY / tileGridSize );
+		return Std.int( (pixelX-padding) / (tileGridSize + spacing) )  +  cWid
+            * Std.int( pixelY / (tileGridSize + spacing) );
 	}
 
 


### PR DESCRIPTION
Updated Tileset to correctly adjust for spacing.

This only resolves the spacing portion of #22, not the padding; I don't have any tilesets with padding to verify.

I didn't add any additional test cases for this because I'm not sure this is how you'd like this support to be added.  I didn't want to put a lot of effort into a new map & test cases until you verified this was the right approach.  I can add them if you're ok with this fix.