### PR TITLE
update ldtk haxe docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ haxelib install ldtk-haxe-api
 
 Please check the **full documentation and tutorials** here:
 
-https://deepnight.net/docs/ldtk/haxe-api/
+https://ldtk.io/docs/game-dev/haxe-in-game-api/
 
 ## Samples
 


### PR DESCRIPTION
updates the link in the readme to the proper docs page, seems like the old one moved and just redirected to the homepage!