### PR TITLE
Add typed Tileset and Layer_Tiles

### DIFF
--- a/src/ldtk/Layer_Tiles.hx
+++ b/src/ldtk/Layer_Tiles.hx
@@ -2,14 +2,18 @@ package ldtk;
 
 import ldtk.Tileset;
 
-typedef Layer_Tiles = TypedLayer_Tiles<EnumValue>;
+typedef Layer_Tiles = TypedLayer_Tiles<Tileset>;
 
-class TypedLayer_Tiles<TTag:EnumValue> extends ldtk.Layer {
+class TypedLayer_Tiles<TTileset:TypedTileset<EnumValue>> extends ldtk.Layer {
 	var tiles : Map<Int, Array<{ tileId:Int, flipBits:Int }>>;
 
-	/** Getter to layer untyped Tileset instance. The typed value is created in macro. **/
-	var untypedTileset(get,never) : TypedTileset<TTag>;
+	/** Getter to layer untyped Tileset instance. **/
+	var untypedTileset(get,never) : TTileset;
 	inline function get_untypedTileset() return cast untypedProject._untypedTilesets.get(tilesetUid);
+
+	/** Getter for this layer's tileset */
+	public var tileset(get,never) : TTileset;
+	inline function get_tileset() return untypedTileset;
 
 	/** Tileset UID **/
 	public var tilesetUid(default,null) : Int;

--- a/src/ldtk/Layer_Tiles.hx
+++ b/src/ldtk/Layer_Tiles.hx
@@ -1,11 +1,15 @@
 package ldtk;
 
-class Layer_Tiles extends ldtk.Layer {
+import ldtk.Tileset;
+
+typedef Layer_Tiles = TypedLayer_Tiles<EnumValue>;
+
+class TypedLayer_Tiles<TTag:EnumValue> extends ldtk.Layer {
 	var tiles : Map<Int, Array<{ tileId:Int, flipBits:Int }>>;
 
 	/** Getter to layer untyped Tileset instance. The typed value is created in macro. **/
-	var untypedTileset(get,never) : ldtk.Tileset;
-		inline function get_untypedTileset() return untypedProject._untypedTilesets.get(tilesetUid);
+	var untypedTileset(get,never) : TypedTileset<TTag>;
+	inline function get_untypedTileset() return cast untypedProject._untypedTilesets.get(tilesetUid);
 
 	/** Tileset UID **/
 	public var tilesetUid(default,null) : Int;

--- a/src/ldtk/Layer_Tiles.hx
+++ b/src/ldtk/Layer_Tiles.hx
@@ -9,11 +9,11 @@ class TypedLayer_Tiles<TTileset:TypedTileset<EnumValue>> extends ldtk.Layer {
 
 	/** Getter to layer untyped Tileset instance. **/
 	var untypedTileset(get,never) : TTileset;
-	inline function get_untypedTileset() return cast untypedProject._untypedTilesets.get(tilesetUid);
+		inline function get_untypedTileset() return cast untypedProject._untypedTilesets.get(tilesetUid);
 
 	/** Getter for this layer's tileset */
 	public var tileset(get,never) : TTileset;
-	inline function get_tileset() return untypedTileset;
+		inline function get_tileset() return untypedTileset;
 
 	/** Tileset UID **/
 	public var tilesetUid(default,null) : Int;

--- a/src/ldtk/Tileset.hx
+++ b/src/ldtk/Tileset.hx
@@ -1,6 +1,8 @@
 package ldtk;
 
-class Tileset {
+typedef Tileset = TypedTileset<EnumValue>;
+
+class TypedTileset<TTag:EnumValue> {
 	var untypedProject: ldtk.Project;
 
 	/** Original parsed JSON object **/
@@ -85,6 +87,16 @@ class Tileset {
 		return Std.int( (pixelX-padding) / tileGridSize )  +  cWid * Std.int( pixelY / tileGridSize );
 	}
 
+	/** Return TRUE if the specifiied tile ID was tagged with given enum `tag`. **/
+	public inline function hasTag(tileId:Int, tag:TTag) {
+		final allTileIds = untypedTags.get( tag.getName() );
+		return allTileIds==null ? false : allTileIds.exists(tileId);
+	}
+
+	/** Return an array of all tags associated with give tile ID. WARNING: this allocates a new array on call. **/
+	public function getAllTags(tileId:Int) : Array<TTag> {
+		throw "getAllTags not implemented";
+	}
 
 	/***************************************************************************
 		HEAPS API

--- a/src/ldtk/macro/TypeBuilder.hx
+++ b/src/ldtk/macro/TypeBuilder.hx
@@ -547,36 +547,45 @@ class TypeBuilder {
 		timer("tilesetClasses");
 		tilesets = new Map();
 		for(t in json.defs.tilesets) {
-			// Create tileset class
-			var parentTypePath : TypePath = { pack: [APP_PACKAGE], name:"Tileset" }
-			var tilesetType : TypeDefinition = {
-				pos : curPos,
-				name : "Tileset_"+t.identifier,
-				pack : modPack,
-				doc: 'Tileset class of atlas "${t.relPath}"',
-				kind : TDClass(parentTypePath),
-				fields : (macro class {
-					override public function new(p,json) {
-						super(p,json);
-					}
-				}).fields,
-			}
-
 			// Enum tags
-			if( t.tagsSourceEnumUid!=null ) {
+			var tilesetType : TypeDefinition;
+			if( t.tagsSourceEnumUid==null ) {
+				// Create tileset class
+				var parentTypePath : TypePath = { pack: [APP_PACKAGE], name:"Tileset" };
+				tilesetType = {
+					pos : curPos,
+					name : "Tileset_"+t.identifier,
+					pack : modPack,
+					doc: 'Tileset class of atlas "${t.relPath}"',
+					kind : TDClass(parentTypePath),
+					fields : (macro class {
+						override public function new(p,json) {
+							super(p,json);
+						}
+					}).fields,
+				}
+			} else {
 				var enumTypeDef = localEnums.get(t.tagsSourceEnumUid);
 				var enumComplexType = Context.getType(enumTypeDef.name).toComplexType();
+				// Create tileset class
+				var parentTypePath : TypePath = { pack: [APP_PACKAGE], name:"Tileset", sub:"TypedTileset", params:[TPType(enumComplexType)] };
+				tilesetType = {
+					pos : curPos,
+					name : "Tileset_"+t.identifier,
+					pack : modPack,
+					doc: 'Tileset class of atlas "${t.relPath}"',
+					kind : TDClass(parentTypePath),
+					fields : (macro class {
+						override public function new(p,json) {
+							super(p,json);
+						}
+					}).fields,
+				}
 				var enumTypeExpr = { pos:curPos, expr:EConst(CIdent(enumTypeDef.name)) }
 				tilesetType.fields = tilesetType.fields.concat( (macro class {
 
-					/** Return TRUE if the specifiied tile ID was tagged with given enum `tag`. **/
-					public inline function hasTag(tileId:Int, tag:$enumComplexType) {
-						final allTileIds = untypedTags.get( tag.getName() );
-						return allTileIds==null ? false : allTileIds.exists(tileId);
-					}
-
 					/** Return an array of all tags associated with give tile ID. WARNING: this allocates a new array on call. **/
-					public function getAllTags(tileId:Int) : Array<$enumComplexType> {
+					override function getAllTags(tileId:Int) : Array<$enumComplexType> {
 						var all = [];
 						for(t in untypedTags.keys()) {
 							if( untypedTags.get(t).exists(tileId) )

--- a/src/ldtk/macro/TypeBuilder.hx
+++ b/src/ldtk/macro/TypeBuilder.hx
@@ -765,8 +765,8 @@ class TypeBuilder {
 					if( l.tilesetDefUid==null || !tilesets.exists(l.tilesetDefUid) )
 						error('Missing default tileset in layer "${l.identifier}"');
 
-					var parentTypePath : TypePath = { pack: [APP_PACKAGE], name:"Layer_Tiles" }
 					var tilesetCT = Context.getType( tilesets.get(l.tilesetDefUid).typeName ).toComplexType();
+					var parentTypePath : TypePath = { pack: [APP_PACKAGE], name:"Layer_Tiles", sub:"TypedLayer_Tiles", params:[TPType(tilesetCT)] };
 					var layerType : TypeDefinition = {
 						pos : curPos,
 						name : "Layer_"+l.identifier,
@@ -774,10 +774,6 @@ class TypeBuilder {
 						doc: "Tile layer",
 						kind : TDClass(parentTypePath),
 						fields : (macro class {
-							public var tileset(get,never) : $tilesetCT;
-								inline function get_tileset() return cast untypedTileset;
-
-
 							override public function new(p,json) {
 								super(p,json);
 							}


### PR DESCRIPTION
I don't know if this is something you're interested in, but it's the direction in which I plan to take my personal fork of ldtk-haxe-api

## The Problem
I find it oddly hard to write generic code for ldtk, that is useful in multiple projects or for multiple types that are built via macros. The use of macros are - I'll admit - a fucking lifesaver and make starting new projects a breeze, but I find myself copying and pasting the same utilizing code from project to project (and sometimes multiple times in the same project)  and changing the class names just to get the same fields that are in every tileset or tile layer but not in the respective base classes

## The Solution
Put those fields and functions in the base classes and use type params to make it easy to pass them around to generic utils without needing to know the specific generated class for each project.

## The Changes
- Rename `Tileset` to `TypedTileset<TTag:EnumValue>`, and add a untyped `Tileset` typedef
- Add `hasTag` and `getAllTags` to the base class, override `getAllTags` in the built types, (I could also make Tileset an abstract class, but that seemed more risky, as it's a recent haxe feature, and maybe not a backward compatible change)
- Rename `Layer_Tiles` to `TypedLayer_Tiles<TTag:EnumValue>` and add a untyped `Layer_Tiles` typedef. In my tools I'm using this for `@:privateAccess layer.untypedTileset
- Add `tileset` field to `Layer_Tiles`
- Built extensions of Tileset and Layer_Tiles now extend their typed versions

Another option, rather than having the old type as a typedef of the new typed class, we could have the typed class extend the untyped version with the newly added typed fields (just thought of this, might explore as it may resolve some covariance issues)

## The future
I think there many other places that would benefit from having more generic type options, I can make an issue listing them out if there's any interest