### PR TITLE
Address the warning given by haxe 5.0.

### DIFF
--- a/src/ldtk/macro/TypeBuilder.hx
+++ b/src/ldtk/macro/TypeBuilder.hx
@@ -1,6 +1,6 @@
 package ldtk.macro;
 
-#if( !macro && !display )
+#if( !macro && !haxe.macro.Context.defined("display") )
 #error "This class should not be used outside of macros"
 #end
 


### PR DESCRIPTION
I have been experimenting with the upstream version of haxe and ran into warnings this PR applies the suggestion given in the message.
```
 [WARNING] (macro) /usr/share/haxe/lib/ldtk-haxe-api/git/src/ldtk/macro/TypeBuilder.hx:3: characters 17-24


   3 | #if( !macro && !display )
     |                 ^^^^^^^
     | (WIfDisplay) Using `display` here doesn't work because #if conditions are evaluated at parse time. In macros, use `haxe.macro.Context.defined("display")` instead.
```